### PR TITLE
Do not stop search on isready

### DIFF
--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -106,7 +106,6 @@ void Uci::listner(IterativeDeeping *it) {
             searchManager.display();
         } else if (token == "isready") {
             knowCommand = true;
-            searchManager.setRunning(0);
             cout << "readyok\n";
         } else if (token == "uci") {
             knowCommand = true;


### PR DESCRIPTION
"isready" is intended for synchronization, to make sure all previous
commands have been read and the engine is still alive and responsive.

The UCI protocol spec explicitly states, that it can be sent during search,
without stopping it. "readyok" shall be sent immediately, before the
search has completed.
