### PR TITLE
Quit when stdin is closed

### DIFF
--- a/src/Uci.cpp
+++ b/src/Uci.cpp
@@ -60,7 +60,9 @@ void Uci::listner(IterativeDeeping *it) {
             perft->join();
             break;
         }
-        getline(cin, command);
+        if (!getline(cin, command)) {
+            break;
+        }
         istringstream uip(command, ios::in);
         getToken(uip, token);
         knowCommand = false;


### PR DESCRIPTION
When stdin gets closed, quit instead of looping forever. This allows for
use of:
- CTRL + d in most shells
- piping commands: echo "isready" | cinnamon
