### PR TITLE
optimize attack king

### DIFF
--- a/src/ChessBoard.h
+++ b/src/ChessBoard.h
@@ -191,9 +191,11 @@ protected:
         u64 semiOpenFile[2];
         u64 isolated[2];
         u64 allPiecesNoPawns[2];
+        u64 posKingBit[2];
         //u64 pinned[2]; anche x regina?
         int kingSecurityDistance[2];
         uchar posKing[2];
+
     } _Tboard;
 
     static constexpr u64 A7bit = 0x80000000000000ULL;

--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -417,8 +417,6 @@ int Eval::evaluateKnight(const u64 enemiesPawns, const u64 notMyBits) {
                 result += p;
                 if (!(chessboard[KNIGHT_BLACK + xside]) &&
                     !(chessboard[BISHOP_BLACK + xside] & ChessBoard::colors(pos))) {
-//                    display();
-//                    cout <<"side "<<side<<endl;
                     result += p;
                 }
             }
@@ -642,24 +640,12 @@ short Eval::getScore(const u64 key, const int side, const int N_PIECE, const int
         bonus_attack_king_black = BONUS_ATTACK_KING[bitCount(structureEval.kingAttackers[WHITE])];
         bonus_attack_king_white = BONUS_ATTACK_KING[bitCount(structureEval.kingAttackers[BLACK])];
     }
-   // display();
-//    cout << structureEval.kingAttackers[WHITE] << " "
-//        << getAllAttackers<WHITE>(structureEval.posKing[WHITE], structureEval.allPieces) << endl;
 
-    ASSERT(structureEval.kingAttackers[WHITE]
-               == getAllAttackers<WHITE>(structureEval.posKing[WHITE], structureEval.allPieces));
-
-
-    if(structureEval.kingAttackers[BLACK]
-        != getAllAttackers<BLACK>(structureEval.posKing[BLACK], structureEval.allPieces)) {
-        cout << structureEval.kingAttackers[BLACK] << " "
-            << getAllAttackers<BLACK>(structureEval.posKing[BLACK], structureEval.allPieces) << endl;
-
-        display();
-        getRes<OPEN>(Tresult);
-    }
-    ASSERT(structureEval.kingAttackers[BLACK]
-               == getAllAttackers<BLACK>(structureEval.posKing[BLACK], structureEval.allPieces));
+//    ASSERT(structureEval.kingAttackers[WHITE]
+//               == getAllAttackers<WHITE>(structureEval.posKing[WHITE], structureEval.allPieces));
+//
+//    ASSERT(structureEval.kingAttackers[BLACK]
+//               == getAllAttackers<BLACK>(structureEval.posKing[BLACK], structureEval.allPieces));
 
     ASSERT(getMobilityCastle(WHITE, structureEval.allPieces) < (int) (sizeof(MOB_CASTLE[phase]) / sizeof(int)));
     ASSERT(getMobilityCastle(BLACK, structureEval.allPieces) < (int) (sizeof(MOB_CASTLE[phase]) / sizeof(int)));

--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -125,10 +125,7 @@ int Eval::evaluatePawn() {
             structureEval.kingAttackers[xside] |= pos;
             result += ATTACK_KING;
         }
-
-        ADD(SCORE_DEBUG.ATTACK_KING_PAWN[side],
-            ATTACK_KING * bitCount(ped_friends & structureEval.kingAttackers[xside]));
-
+       
         /// blocked
         result -= (!(PAWN_FORK_MASK[side][o] & structureEval.allPiecesSide[xside])) &&
             (structureEval.allPieces & (shiftForward<side, 8>(pos))) ? PAWN_BLOCKED : 0;

--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "Eval.h"
+#include "ChessBoard.h"
 
 using namespace _eval;
 u64 *Eval::evalHash;
@@ -79,10 +80,6 @@ int Eval::evaluatePawn() {
         ADD(SCORE_DEBUG.ENEMIES_PAWNS_ALL[side], -ENEMIES_PAWNS_ALL);
     }
 
-    // 4.
-    result += ATTACK_KING * bitCount(ped_friends & structureEval.kingAttackers[xside]);
-    ADD(SCORE_DEBUG.ATTACK_KING_PAWN[side],
-        ATTACK_KING * bitCount(ped_friends & structureEval.kingAttackers[xside]));
 
 // 5. space
     if (phase == OPEN) {
@@ -122,6 +119,15 @@ int Eval::evaluatePawn() {
     for (u64 p = ped_friends; p; RESET_LSB(p)) {
         const int o = BITScanForward(p);
         u64 pos = POW2[o];
+
+        // 4. attack king
+        if (structureEval.posKingBit[xside] & PAWN_FORK_MASK[side][o]) {
+            structureEval.kingAttackers[xside] |= pos;
+            result += ATTACK_KING;
+        }
+
+        ADD(SCORE_DEBUG.ATTACK_KING_PAWN[side],
+            ATTACK_KING * bitCount(ped_friends & structureEval.kingAttackers[xside]));
 
         /// blocked
         result -= (!(PAWN_FORK_MASK[side][o] & structureEval.allPiecesSide[xside])) &&
@@ -214,9 +220,15 @@ int Eval::evaluateBishop(const u64 enemies) {
     for (; bishop; RESET_LSB(bishop)) {
         const int o = BITScanForward(bishop);
         // 5. mobility
+
         u64 captured = getDiagCapture(o, structureEval.allPieces, enemies);
         ASSERT(bitCount(captured) + getDiagShiftCount(o, structureEval.allPieces) <
             (int) (sizeof(MOB_BISHOP) / sizeof(int)));
+
+        if (captured & structureEval.posKingBit[side ^ 1]) {
+            structureEval.kingAttackers[side ^ 1] |= POW2[o];
+        }
+
         result += MOB_BISHOP[phase][bitCount(captured) + getDiagShiftCount(o, structureEval.allPieces)];
         ADD(SCORE_DEBUG.MOB_BISHOP[side],
             MOB_BISHOP[phase][bitCount(captured) + getDiagShiftCount(o, structureEval.allPieces)]);
@@ -247,7 +259,6 @@ int Eval::evaluateBishop(const u64 enemies) {
                 }
             }
         }
-        RESET_LSB(bishop);
     }
     return result;
 }
@@ -284,9 +295,12 @@ int Eval::evaluateQueen(const u64 enemies) {
         const int o = BITScanForward(queen);
         ASSERT(structureEval.allPieces == structureEval.allPieces);
         // 3. mobility
-        result += MOB_QUEEN[phase][getMobilityQueen(o, enemies, structureEval.allPieces)];
-        ADD(SCORE_DEBUG.MOB_QUEEN[side], MOB_QUEEN[phase][getMobilityQueen(o, enemies, structureEval.allPieces)]);
+        u64 x = getMobilityQueen(o, enemies, structureEval.allPieces);
+        result += MOB_QUEEN[phase][bitCount(x)];
+        ADD(SCORE_DEBUG.MOB_QUEEN[side], MOB_QUEEN[phase][bitCount(x)]);
 
+        if (x & structureEval.posKingBit[side ^ 1])
+            structureEval.kingAttackers[side ^ 1] |= POW2[o];
         // 4. half open file
         if ((chessboard[side ^ 1] & FILE_[o])) {
             ADD(SCORE_DEBUG.HALF_OPEN_FILE_Q[side], HALF_OPEN_FILE_Q);
@@ -388,8 +402,10 @@ int Eval::evaluateKnight(const u64 enemiesPawns, const u64 notMyBits) {
 
         // 5. mobility
         ASSERT(bitCount(notMyBits & KNIGHT_MASK[pos]) < (int) (sizeof(MOB_KNIGHT) / sizeof(int)));
-        result += MOB_KNIGHT[bitCount(notMyBits & KNIGHT_MASK[pos])];
-        ADD(SCORE_DEBUG.MOB_KNIGHT[side], MOB_KNIGHT[bitCount(notMyBits & KNIGHT_MASK[pos])]);
+        u64 mob = notMyBits & KNIGHT_MASK[pos];
+        result += MOB_KNIGHT[bitCount(mob)];
+        if (mob & structureEval.posKingBit[side ^ 1]) structureEval.kingAttackers[side ^ 1] |= POW2[pos];
+        ADD(SCORE_DEBUG.MOB_KNIGHT[side], MOB_KNIGHT[bitCount(mob)]);
 
         // 6. outposts
         auto p = KNIGHT_OUTPOST[side][pos];
@@ -473,9 +489,12 @@ int Eval::evaluateRook(const u64 king, const u64 enemies, const u64 friends) {
     for (; rook; RESET_LSB(rook)) {
         const int o = BITScanForward(rook);
         //mobility
-        ASSERT(getMobilityRook(o, enemies, friends) < (int) (sizeof(MOB_ROOK[phase]) / sizeof(int)));
-        result += MOB_ROOK[phase][getMobilityRook(o, enemies, friends)];
-        ADD(SCORE_DEBUG.MOB_ROOK[side], MOB_ROOK[phase][getMobilityRook(o, enemies, friends)]);
+        u64 mob = getMobilityRook(o, enemies, friends);
+        if (mob & structureEval.posKingBit[side ^ 1]) structureEval.kingAttackers[side ^ 1] |= POW2[o];
+
+        ASSERT(bitCount(mob) < (int) (sizeof(MOB_ROOK[phase]) / sizeof(int)));
+        result += MOB_ROOK[phase][bitCount(mob)];
+        ADD(SCORE_DEBUG.MOB_ROOK[side], MOB_ROOK[phase][bitCount(mob)]);
 
         if (phase != OPEN) {
             // .8 Penalise if Rook is Blocked Horizontally
@@ -586,8 +605,10 @@ short Eval::getScore(const u64 key, const int side, const int N_PIECE, const int
     structureEval.allPieces = structureEval.allPiecesSide[BLACK] | structureEval.allPiecesSide[WHITE];
     structureEval.posKing[BLACK] = (uchar) BITScanForward(chessboard[KING_BLACK]);
     structureEval.posKing[WHITE] = (uchar) BITScanForward(chessboard[KING_WHITE]);
-    structureEval.kingAttackers[WHITE] = getAllAttackers<WHITE>(structureEval.posKing[WHITE], structureEval.allPieces);
-    structureEval.kingAttackers[BLACK] = getAllAttackers<BLACK>(structureEval.posKing[BLACK], structureEval.allPieces);
+    structureEval.posKingBit[BLACK] = POW2[structureEval.posKing[BLACK]];
+    structureEval.posKingBit[WHITE] = POW2[structureEval.posKing[WHITE]];
+    structureEval.kingAttackers[WHITE] = structureEval.kingAttackers[BLACK] = 0;
+
 //    if (phase == END) {
 //
 //        structureEval.pinned[BLACK] = getPinned<BLACK>(structureEval.allPieces, structureEval.allPiecesSide[BLACK],
@@ -600,12 +621,7 @@ short Eval::getScore(const u64 key, const int side, const int N_PIECE, const int
 //    }
     openFile<WHITE>();
     openFile<BLACK>();
-    int bonus_attack_king_black = 0;
-    int bonus_attack_king_white = 0;
-    if (phase != OPEN) {
-        bonus_attack_king_black = BONUS_ATTACK_KING[bitCount(structureEval.kingAttackers[WHITE])];
-        bonus_attack_king_white = BONUS_ATTACK_KING[bitCount(structureEval.kingAttackers[BLACK])];
-    }
+
     _Tresult Tresult;
     switch (phase) {
         case OPEN :
@@ -620,6 +636,30 @@ short Eval::getScore(const u64 key, const int side, const int N_PIECE, const int
         default:
             break;
     }
+    int bonus_attack_king_black = 0;
+    int bonus_attack_king_white = 0;
+    if (phase != OPEN) {
+        bonus_attack_king_black = BONUS_ATTACK_KING[bitCount(structureEval.kingAttackers[WHITE])];
+        bonus_attack_king_white = BONUS_ATTACK_KING[bitCount(structureEval.kingAttackers[BLACK])];
+    }
+   // display();
+//    cout << structureEval.kingAttackers[WHITE] << " "
+//        << getAllAttackers<WHITE>(structureEval.posKing[WHITE], structureEval.allPieces) << endl;
+
+    ASSERT(structureEval.kingAttackers[WHITE]
+               == getAllAttackers<WHITE>(structureEval.posKing[WHITE], structureEval.allPieces));
+
+
+    if(structureEval.kingAttackers[BLACK]
+        != getAllAttackers<BLACK>(structureEval.posKing[BLACK], structureEval.allPieces)) {
+        cout << structureEval.kingAttackers[BLACK] << " "
+            << getAllAttackers<BLACK>(structureEval.posKing[BLACK], structureEval.allPieces) << endl;
+
+        display();
+        getRes<OPEN>(Tresult);
+    }
+    ASSERT(structureEval.kingAttackers[BLACK]
+               == getAllAttackers<BLACK>(structureEval.posKing[BLACK], structureEval.allPieces));
 
     ASSERT(getMobilityCastle(WHITE, structureEval.allPieces) < (int) (sizeof(MOB_CASTLE[phase]) / sizeof(int)));
     ASSERT(getMobilityCastle(BLACK, structureEval.allPieces) < (int) (sizeof(MOB_CASTLE[phase]) / sizeof(int)));

--- a/src/GenMoves.cpp
+++ b/src/GenMoves.cpp
@@ -114,7 +114,7 @@ u64 GenMoves::getMobilityQueen(const int position, const u64 enemies, const u64 
         getDiagShiftAndCapture(position, enemies, allpieces);
 }
 
-int GenMoves::getMobilityRook(const int position, const u64 enemies, const u64 friends) {
+u64 GenMoves::getMobilityRook(const int position, const u64 enemies, const u64 friends) {
     ASSERT_RANGE(position, 0, 63);
     return performRankFileCaptureAndShift(position, enemies, enemies | friends);
 }

--- a/src/GenMoves.cpp
+++ b/src/GenMoves.cpp
@@ -51,11 +51,11 @@ bool GenMoves::performRankFileCapture(const int piece, const u64 enemies, const 
     return false;
 }
 
-int GenMoves::performRankFileCaptureAndShiftCount(const int position, const u64 enemies, const u64 allpieces) {
+u64 GenMoves::performRankFileCaptureAndShift(const int position, const u64 enemies, const u64 allpieces) {
     ASSERT_RANGE(position, 0, 63);
     u64 rankFile = getRankFile(position, allpieces);
     rankFile = (rankFile & enemies) | (rankFile & ~allpieces);
-    return bitCount(rankFile);
+    return rankFile;
 }
 
 bool GenMoves::performDiagCapture(const int piece, const u64 enemies, const int side, const u64 allpieces) {
@@ -108,15 +108,15 @@ bool GenMoves::generateCaptures(const int side, const u64 enemies, const u64 fri
     return side ? generateCaptures<WHITE>(enemies, friends) : generateCaptures<BLACK>(enemies, friends);
 }
 
-int GenMoves::getMobilityQueen(const int position, const u64 enemies, const u64 allpieces) {
+u64 GenMoves::getMobilityQueen(const int position, const u64 enemies, const u64 allpieces) {
     ASSERT_RANGE(position, 0, 63);
-    return performRankFileCaptureAndShiftCount(position, enemies, allpieces) +
-        bitCount(getDiagShiftAndCapture(position, enemies, allpieces));
+    return performRankFileCaptureAndShift(position, enemies, allpieces) +
+        getDiagShiftAndCapture(position, enemies, allpieces);
 }
 
 int GenMoves::getMobilityRook(const int position, const u64 enemies, const u64 friends) {
     ASSERT_RANGE(position, 0, 63);
-    return performRankFileCaptureAndShiftCount(position, enemies, enemies | friends);
+    return performRankFileCaptureAndShift(position, enemies, enemies | friends);
 }
 
 void GenMoves::setPerft(const bool b) {

--- a/src/GenMoves.h
+++ b/src/GenMoves.h
@@ -350,7 +350,7 @@ protected:
 
     int getMobilityCastle(const int side, const u64 allpieces) const;
 
-    int getMobilityQueen(const int position, const u64 enemies, const u64 allpieces);
+    u64 getMobilityQueen(const int position, const u64 enemies, const u64 allpieces);
 
     void initKillerHeuristic();
 
@@ -649,7 +649,7 @@ private:
         }
     }
 
-    int performRankFileCaptureAndShiftCount(const int position, const u64 enemies, const u64 allpieces);
+    u64 performRankFileCaptureAndShift(const int position, const u64 enemies, const u64 allpieces);
 
     void popStackMove() {
         ASSERT(repetitionMapCount > 0);

--- a/src/GenMoves.h
+++ b/src/GenMoves.h
@@ -341,12 +341,12 @@ protected:
         return getAttackers<side, true>(position, allpieces);
     }
 
-    template<int side>
-    u64 getAllAttackers(const int position, const u64 allpieces) const {
-        return getAttackers<side, false>(position, allpieces);
-    }
+//    template<int side>
+//    u64 getAllAttackers(const int position, const u64 allpieces) const {
+//        return getAttackers<side, false>(position, allpieces);
+//    }
 
-    int getMobilityRook(const int position, const u64 enemies, const u64 friends);
+    u64 getMobilityRook(const int position, const u64 enemies, const u64 friends);
 
     int getMobilityCastle(const int side, const u64 allpieces) const;
 


### PR DESCRIPTION
----------- optimize attack king ------------
a

ratings
Rank Name Elo + - games score oppo. draws
1 Cinnamon 2.1-55_perc 18 4 3 59194 58% -18 23%
2 Cinnamon 2.0 -18 3 4 59194 42% 18 23%

los
Ci Ci
Cinnamon 2.1-55_perc 100
Cinnamon 2.0 0

PLAYER : RATING POINTS PLAYED (%)
1 Cinnamon 2.1-55_perc : 2317.7 32579.5 59195 57.8%
2 Cinnamon 2.0 : 2282.3 26615.5 59195 42.2%

White advantage = 0.00
Draw rate (equal opponents) = 50.00 %